### PR TITLE
 Add User Setting to Toggle Key Click Sound

### DIFF
--- a/vs-music-player/.vscode/launch.json
+++ b/vs-music-player/.vscode/launch.json
@@ -10,7 +10,8 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				 "--disable-extensions" 
 			]
 		}
 	]

--- a/vs-music-player/CHANGELOG.md
+++ b/vs-music-player/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the "vs-music-player" extension will be documented in thi
 
 ### Added
 - **Click Sound Toggle Setting**:
-  - Added a new user setting `vs-music-player.keyClickSound` to control the click sound effect during text editing.
+  - Added a new user setting `vs-music-player.keyClickSoundEffect` to control the click sound effect during text editing.
   - Default value: `true`
   - Description: "Enables or disables the click-sound effect when interacting with the music player."
   - Users can modify this in their **Settings UI** or `settings.json`.

--- a/vs-music-player/CHANGELOG.md
+++ b/vs-music-player/CHANGELOG.md
@@ -3,8 +3,20 @@
 All notable changes to the "vs-music-player" extension will be documented in this file.
 
 ---
+## [Version 0.2.1] - 2025-07-12
 
-## \[Version 0.1.8] - 2025-07-01
+### Added
+- **Click Sound Toggle Setting**:
+  - Added a new user setting `vs-music-player.keyClickSound` to control the click sound effect during text editing.
+  - Default value: `true`
+  - Description: "Enables or disables the click-sound effect when interacting with the music player."
+  - Users can modify this in their **Settings UI** or `settings.json`.
+
+---
+
+> 💡 This setting helps users mute or enable feedback sound without needing to reload the extension.
+
+## [Version 0.1.8] - 2025-07-01
 
 ### Added
 

--- a/vs-music-player/package.json
+++ b/vs-music-player/package.json
@@ -36,7 +36,17 @@
         "command": "vs-music-player.openMusicSelector",
         "title": "Open Music Player"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "VS Music Player Settings",
+      "properties": {
+        "vs-music-player.keyClickSoundEffect": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enables or disables the click sound effect when interacting with the music player."
+        }
+      }
+    }
   },
   "scripts": {
     "lint": "eslint .",

--- a/vs-music-player/src/clickSound.js
+++ b/vs-music-player/src/clickSound.js
@@ -1,8 +1,11 @@
 const { exec } = require("child_process");
 const path = require("path");
+const vscode = require("vscode");
+
+let textChangeListener; 
 
 function setupClickSound(context, ffplayPath) {
-  const clickSoundPath = path.join(context.extensionPath,"media", "click.wav");
+  const clickSoundPath = path.join(context.extensionPath, "media", "click.wav");
 
   function playClick() {
     exec(`"${ffplayPath}" -nodisp -autoexit "${clickSoundPath}"`, (err) => {
@@ -10,9 +13,26 @@ function setupClickSound(context, ffplayPath) {
     });
   }
 
-  require("vscode").workspace.onDidChangeTextDocument(() => {
+
+  if (textChangeListener) {
+    textChangeListener.dispose();
+  }
+
+  textChangeListener = vscode.workspace.onDidChangeTextDocument(() => {
     playClick();
   });
+
+  context.subscriptions.push(textChangeListener);
 }
 
-module.exports = { setupClickSound };
+function teardownClickSound() {
+  if (textChangeListener) {
+    textChangeListener.dispose();
+    textChangeListener = null;
+  }
+}
+
+module.exports = {
+  setupClickSound,
+  teardownClickSound,
+};

--- a/vs-music-player/src/config.js
+++ b/vs-music-player/src/config.js
@@ -1,0 +1,12 @@
+const vscode =require("vscode");
+
+function getExtentionConfig(){
+    const config = vscode.workspace.getConfiguration("vs-music-player");
+    
+    return{
+        keyClickSoundEffect:config.get("keyClickSoundEffect",true),
+
+    }
+}
+
+module.exports = {getExtentionConfig}


### PR DESCRIPTION
This PR introduces a new configuration setting:
vs-music-player.keyClickSoundEffect — a boolean flag that allows users to enable or disable the key click sound effect when interacting with the extension.

**What's Changed**
✅ Added configuration property in package.json with description and default value (true).

✅ Implemented logic in the extension to conditionally play click sound based on user setting.

✅ Added real-time listener for setting changes using onDidChangeConfiguration.

✅ Updated setupClickSound to safely register/dispose event listeners.

✅ Created teardownClickSound to remove event listener when setting is turned off.

✅ Updated CHANGELOG.md with version 0.2.1 entry.

**Why This Is Useful**
Gives users control over audible feedback.

Supports quiet working environments or personal preference.

Enhances overall usability and flexibility of the extension.